### PR TITLE
Fix Bug issue #7 control source database with var mailchimp_database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# dbt_mailchimp_source v0.1.1
+
+## Fixes
+- Updating src_mailchimp database variable to reflect README files. Update `database` to `mailchimp_database`.([#7](https://github.com/fivetran/dbt_mailchimp_source/pull/8)).
+
+## Contributors
+- @dfagnan ([#7](https://github.com/fivetran/dbt_mailchimp_source/pull/8)).
+
 # dbt_mailchimp_source v0.1.0
 
 ## Initial Release

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,6 +3,8 @@ version: '0.1.0'
 
 config-version: 2
 
+profile: 'analytics-snowflake'
+
 models:
     mailchimp_source:
         +materialized: table

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'mailchimp_source'
-version: '0.1.0'
+version: '0.1.1'
 
 config-version: 2
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,8 +3,6 @@ version: '0.1.0'
 
 config-version: 2
 
-profile: 'analytics-snowflake'
-
 models:
     mailchimp_source:
         +materialized: table
@@ -28,4 +26,4 @@ vars:
         unsubscribe: "{{ source('mailchimp','unsubscribe') }}"
         mailchimp__members_pass_through_columns: []
         mailchimp_using_segments: True
-        mailchimp_using_automations: True 
+        mailchimp_using_automations: True

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'mailchimp_source_integration_tests'
-version: '0.1.0'
+version: '0.1.1'
 
 config-version: 2
 

--- a/models/src_mailchimp.yml
+++ b/models/src_mailchimp.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: mailchimp
     schema: "{{ var('mailchimp_schema', 'mailchimp') }}"
-    database: "{{ var('database', target.database) }}"
+    database: "{{ var('mailchimp_database', target.database) }}"
 
     loader: fivetran
     loaded_at_field: _fivetran_synced


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
David Fagnan in trial with Fivetran 

**What change(s) does this PR introduce?** 
Changes the variable controlling the source database (`mailchimp_database` to match the readme).

**Does this PR introduce a breaking change?**
- [X ] Yes 
Users who rely on `database` to control the source database rather than relying on the default or readme variable `mailchimp_database`

**Is this PR in response to a previously created Issue**
- [ X] Yes, Issue https://github.com/fivetran/dbt_mailchimp_source/issues/7

**How did you test the PR changes?** 
- [ X] Other (please provide additional testing details below)
I tested it within my project that depended on `mailchimp_source`.

If there are ideas to add a formal test verifying this I am all ears!

**Select which warehouse(s) were used to test the PR**
- [X] Snowflake


**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:


